### PR TITLE
Add Flask-based local chatbot

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,57 @@
+import json
+from flask import Flask, request, jsonify, render_template
+import requests
+
+app = Flask(__name__, static_url_path='/static', static_folder='static', template_folder='templates')
+
+# Load invisible context once on startup
+with open('context.txt', 'r') as f:
+    INVISIBLE_CONTEXT = f.read().strip()
+
+# Load customer configuration once on startup
+with open('customer_config.json', 'r') as f:
+    CUSTOMER_CONFIG = json.load(f)
+
+@app.route('/')
+def index():
+    return render_template('test.html')
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    data = request.get_json(silent=True) or {}
+    message = data.get('message')
+    customer_id = data.get('customer_id')
+    if not message or not customer_id:
+        return jsonify({'error': 'Missing message or customer_id'}), 400
+
+    customer = CUSTOMER_CONFIG.get(customer_id)
+    if not customer:
+        return jsonify({'error': 'Invalid customer_id'}), 400
+
+    headers = {
+        'Authorization': f"Bearer {customer['api_key']}",
+        'Content-Type': 'application/json',
+        'HTTP-Referer': 'http://localhost:5000',
+        'X-Title': 'Local Chatbot'
+    }
+
+    payload = {
+        'model': customer.get('model', 'mistralai/mixtral-8x7b-instruct'),
+        'messages': [
+            {'role': 'system', 'content': INVISIBLE_CONTEXT},
+            {'role': 'user', 'content': message}
+        ]
+    }
+
+    try:
+        resp = requests.post('https://openrouter.ai/api/v1/chat/completions', headers=headers, json=payload, timeout=30)
+        if resp.status_code != 200:
+            return jsonify({'error': 'API error', 'detail': resp.text}), 500
+        data = resp.json()
+        reply = data['choices'][0]['message']['content']
+        return jsonify({'reply': reply})
+    except requests.exceptions.RequestException as e:
+        return jsonify({'error': 'Request failed', 'detail': str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/context.txt
+++ b/context.txt
@@ -1,0 +1,1 @@
+You are a helpful assistant that answers questions with short, polite, and clear answers.

--- a/customer_config.json
+++ b/customer_config.json
@@ -1,0 +1,6 @@
+{
+  "cust001": {
+    "api_key": "your-openrouter-key",
+    "model": "mistralai/mixtral-8x7b-instruct"
+  }
+}

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,0 +1,51 @@
+(function() {
+  const script = document.currentScript;
+  const customerId = script.dataset.id || '';
+
+  const button = document.createElement('div');
+  button.id = 'chat-button';
+  button.textContent = '💬';
+  document.body.appendChild(button);
+
+  const chatWindow = document.createElement('div');
+  chatWindow.id = 'chat-window';
+  chatWindow.innerHTML = '<div id="chat-messages"></div><input id="chat-input" placeholder="Type a message" />';
+  document.body.appendChild(chatWindow);
+  chatWindow.style.display = 'none';
+
+  button.addEventListener('click', () => {
+    chatWindow.style.display = chatWindow.style.display === 'none' ? 'block' : 'none';
+  });
+
+  const input = chatWindow.querySelector('#chat-input');
+  const messagesDiv = chatWindow.querySelector('#chat-messages');
+
+  function addMessage(text, cls) {
+    const div = document.createElement('div');
+    div.className = cls;
+    div.textContent = text;
+    messagesDiv.appendChild(div);
+    messagesDiv.scrollTop = messagesDiv.scrollHeight;
+  }
+
+  input.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter' && this.value.trim() !== '') {
+      const msg = this.value.trim();
+      addMessage(msg, 'user');
+      this.value = '';
+      fetch('/chat', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({message: msg, customer_id: customerId})
+      })
+      .then(r => r.json())
+      .then(d => {
+        if (d.reply) addMessage(d.reply, 'bot');
+        else if (d.error) addMessage('Error: ' + d.error, 'error');
+      })
+      .catch(err => {
+        addMessage('Error: ' + err, 'error');
+      });
+    }
+  });
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,58 @@
+#chat-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: #007bff;
+  color: #fff;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 20px;
+  z-index: 1000;
+}
+
+#chat-window {
+  position: fixed;
+  bottom: 70px;
+  right: 20px;
+  width: 300px;
+  max-height: 400px;
+  border: 1px solid #ccc;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  font-family: Arial, sans-serif;
+  z-index: 1000;
+}
+
+#chat-messages {
+  flex: 1;
+  padding: 10px;
+  overflow-y: auto;
+}
+
+#chat-input {
+  border: none;
+  border-top: 1px solid #ccc;
+  padding: 10px;
+  outline: none;
+}
+
+#chat-messages .user {
+  text-align: right;
+  margin: 5px 0;
+}
+
+#chat-messages .bot {
+  text-align: left;
+  margin: 5px 0;
+}
+
+#chat-messages .error {
+  color: red;
+  margin: 5px 0;
+}

--- a/templates/test.html
+++ b/templates/test.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <title>Chat Widget Test</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <h1>Chat Widget Test Page</h1>
+  <p>Use the chat bubble in the bottom-right corner.</p>
+  <script src="/static/chat.js" data-id="cust001"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a small Flask app with `/chat` endpoint that uses OpenRouter
- add OpenRouter config and invisible context files
- implement floating chat widget (JS/CSS)
- add test page to load the widget

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68545cf4d0c883338c00815c4e64446d